### PR TITLE
Fix Unhandled exception(List Generics) for ImageSequences

### DIFF
--- a/lib/nima.dart
+++ b/lib/nima.dart
@@ -104,8 +104,8 @@ class FlutterActorImage extends ActorImage
 
 			int uvStride = 8;
 			int uvRow = currentFrame * uvStride;
-			Iterable it = this.sequenceUVs.getRange(uvRow, uvRow + uvStride);
-			List uvList = new List.from(it);
+			Iterable<double> it = this.sequenceUVs.getRange(uvRow, uvRow + uvStride);
+			List<double> uvList = new List.from(it);
 			_uvBuffer = new Float32List.fromList(uvList);
 		}
 		_canvasVertices = new ui.Vertices.raw(ui.VertexMode.triangles, _vertexBuffer, indices: _indices, textureCoordinates: _uvBuffer);


### PR DESCRIPTION
When using ImageSequences exported file(.nima and .png) the following error occurred.

```
[VERBOSE-2:dart_error.cc(16)] Unhandled exception:
type 'List<dynamic>' is not a subtype of type 'List<double>' where
```

So, I fixed generics type.


```
$ flutter doctor
Doctor summary (to see all details, run flutter doctor -v):
[✓] Flutter (Channel beta, v0.3.2, on Mac OS X 10.13.2 17C88, locale ja-JP)
[✓] Android toolchain - develop for Android devices (Android SDK 27.0.3)
[✓] iOS toolchain - develop for iOS devices (Xcode 9.2)
[✓] Android Studio (version 3.1)
```