### PR TITLE
fix `The method 'advance' was called on null`

### DIFF
--- a/lib/nima_actor.dart
+++ b/lib/nima_actor.dart
@@ -275,6 +275,12 @@ class NimaActorRenderObject extends RenderBox {
   }
 
   bool _advance(double elapsedSeconds) {
+    // _actor might not immediately be available, because it is asynchronously init'ed in
+    // `set filename(String value)`
+    if(_actor == null) {
+      return _isPlaying;
+    }
+
     int lastFullyMixed = -1;
     double lastMix = 0.0;
 


### PR DESCRIPTION
Fix https://github.com/flutter/slideplayer/pull/8#issuecomment-511592969. The reason is that `_actor` might not immediately be available, because it is asynchronously init'ed in `set filename(String value)`